### PR TITLE
Dialogue system

### DIFF
--- a/src/components/dialogue.ts
+++ b/src/components/dialogue.ts
@@ -1,0 +1,85 @@
+// Authors: Omar Muhammad
+
+import DialogueBox from './dialogueBox'
+import type UI from './ui'
+
+export default class DialogueManager {
+    dialogueBox: DialogueBox
+    currentIndex: number
+    lines: [string, number][] = []
+
+    constructor(public ui: UI) {
+        this.dialogueBox = new DialogueBox(ui)
+    }
+
+    get visible() { return this.dialogueBox.visible }
+
+    create() {
+        this.dialogueBox.create()
+    }
+
+    show(lines?: (string | string[])[]) {
+        if (!lines) {
+            this.dialogueBox.show()
+            return
+        }
+
+        if (lines.length === 0) {
+            return
+        }
+
+        const processedLines: [string, number][] = []
+        for (const info of lines) {
+            if (typeof info === 'string') {
+                processedLines.push([info, 0])
+                continue
+            }
+
+            if (info.length === 0) continue
+
+            let text = info[0]
+            processedLines.push([text, 0])
+
+            for (let i = 1; i < info.length; i++) {
+                const el = info[i]
+                text += el
+                processedLines.push([text, text.length - el.length])
+            }
+        }
+
+        this.currentIndex = -1
+        this.lines = processedLines
+        this.moveNext()
+        this.dialogueBox.show()
+    }
+
+    hide() {
+        this.dialogueBox.hide()
+    }
+
+    moveNext() {
+        this.dialogueBox.skipAnimation()
+
+        this.currentIndex++
+        if (this.currentIndex < this.lines.length) {
+            const info = this.lines[this.currentIndex]
+            this.dialogueBox.setText(info[0] ?? '')
+            this.dialogueBox.setInitialProgress(info[1] ?? 0)
+            this.dialogueBox.draw()
+        } else {
+            this.lines = []
+            this.hide()
+        }
+    }
+
+    skipOrMoveNext() {
+        // if the text is currently animating, skip and return
+        if (this.dialogueBox.animating) {
+            this.dialogueBox.skipAnimation()
+            return
+        }
+
+        // otherwise, move to the next line
+        this.moveNext()
+    }
+}

--- a/src/components/dialogueBox.ts
+++ b/src/components/dialogueBox.ts
@@ -1,0 +1,110 @@
+// Authors: Omar Muhammad
+// Based on code from https://gamedevacademy.org/create-a-dialog-modal-plugin-in-phaser-3-part-1
+
+import UI from './ui'
+import { CANVAS_WIDTH, CANVAS_HEIGHT } from '../constants'
+
+const WIDTH = Math.floor(CANVAS_WIDTH * 0.75)
+const HEIGHT = Math.floor(CANVAS_HEIGHT * 0.3)
+const X = Math.floor((CANVAS_WIDTH - WIDTH) / 2)
+const Y = CANVAS_HEIGHT - HEIGHT - 20
+const DELAY = 50
+
+const ALPHA = 0.8
+const COLOR = 0x303030
+const BORDER_ALPHA = 1
+const BORDER_COLOR = 0x907748
+const BORDER_THICKNESS = 3
+const PADDING = 16
+
+export default class DialogueBox {
+    graphics: Phaser.GameObjects.Graphics
+    targetText: string
+    text: Phaser.GameObjects.Text
+    visible: boolean
+    animateEvent: Phaser.Time.TimerEvent
+    animateProgress = 0
+
+    constructor(public ui: UI) {}
+
+    create() {
+        this.visible = false
+        this.graphics = this.ui.scene.add.graphics()
+            .setVisible(false)
+            .setScrollFactor(0)
+    }
+
+    setText(text: string) {
+        this.targetText = text
+        this.draw()
+    }
+
+    draw() {
+        if (!this.graphics) return
+
+        this.graphics.clear()
+
+        // draw the border
+        this.graphics.lineStyle(BORDER_THICKNESS, BORDER_COLOR, BORDER_ALPHA).strokeRect(X, Y, WIDTH, HEIGHT)
+
+        // draw the box
+        this.graphics.fillStyle(COLOR, ALPHA).fillRect(X + 1, Y + 1, WIDTH - 1, HEIGHT - 1)
+
+        // draw the text
+        this.text?.destroy()
+        this.animateEvent?.remove()
+
+        const text = this.ui.scene.make.text({
+            x: X + PADDING,
+            y: Y + PADDING,
+            text: '',
+            visible: this.visible,
+            scrollFactor: 0,
+            style: {
+                wordWrap: {
+                    width: WIDTH - PADDING * 2
+                }
+            }
+        })
+
+        this.text = text
+        this.animateProgress = 0
+        this.animateEvent = this.ui.scene.time.addEvent({
+            delay: DELAY,
+            loop: true,
+            callback: () => {
+                if (this.text !== text) return
+                this.animateProgress++
+                this.text.setText(this.targetText.slice(0, this.animateProgress))
+
+                if (this.animateProgress === this.targetText.length) {
+                    this.animateEvent.remove()
+                }
+            }
+        })
+    }
+
+    show() {
+        this.visible = true
+        this.graphics.setVisible(true)
+        this.text.setVisible(true)
+        this.draw()
+    }
+
+    hide() {
+        this.visible = false
+        this.graphics.setVisible(false)
+        this.text.setVisible(false)
+    }
+}
+
+
+interface DialogueBoxOptions {
+    color?: number
+    alpha?: number
+    height?: number
+    borderColor?: number
+    borderAlpha?: number
+    borderThickness?: number
+    padding?: number
+}

--- a/src/components/dialogueBox.ts
+++ b/src/components/dialogueBox.ts
@@ -19,16 +19,17 @@ const PADDING = 16
 
 export default class DialogueBox {
     graphics: Phaser.GameObjects.Graphics
-    targetText: string
     text: Phaser.GameObjects.Text
-    visible: boolean
     animateEvent: Phaser.Time.TimerEvent
+    animating = false
+    visible = false
     animateProgress = 0
+    initialProgress = 0
+    targetText = ''
 
     constructor(public ui: UI) {}
 
     create() {
-        this.visible = false
         this.graphics = this.ui.scene.add.graphics()
             .setVisible(false)
             .setScrollFactor(0)
@@ -36,7 +37,18 @@ export default class DialogueBox {
 
     setText(text: string) {
         this.targetText = text
-        this.draw()
+    }
+
+    setInitialProgress(progress: number) {
+        this.initialProgress = progress
+    }
+
+    skipAnimation() {
+        if (!this.animating) return
+
+        this.animateEvent?.remove()
+        this.text.setText(this.targetText)
+        this.animating = false
     }
 
     draw() {
@@ -57,7 +69,7 @@ export default class DialogueBox {
         const text = this.ui.scene.make.text({
             x: X + PADDING,
             y: Y + PADDING,
-            text: '',
+            text: this.targetText.slice(0, this.initialProgress),
             visible: this.visible,
             scrollFactor: 0,
             style: {
@@ -68,17 +80,18 @@ export default class DialogueBox {
         })
 
         this.text = text
-        this.animateProgress = 0
+        this.animateProgress = this.initialProgress
+        this.animating = true
         this.animateEvent = this.ui.scene.time.addEvent({
             delay: DELAY,
             loop: true,
             callback: () => {
-                if (this.text !== text) return
                 this.animateProgress++
                 this.text.setText(this.targetText.slice(0, this.animateProgress))
 
                 if (this.animateProgress === this.targetText.length) {
-                    this.animateEvent.remove()
+                    this.animateEvent?.remove()
+                    this.animating = false
                 }
             }
         })
@@ -87,24 +100,12 @@ export default class DialogueBox {
     show() {
         this.visible = true
         this.graphics.setVisible(true)
-        this.text.setVisible(true)
-        this.draw()
+        this.text?.setVisible(true)
     }
 
     hide() {
         this.visible = false
         this.graphics.setVisible(false)
-        this.text.setVisible(false)
+        this.text?.setVisible(false)
     }
-}
-
-
-interface DialogueBoxOptions {
-    color?: number
-    alpha?: number
-    height?: number
-    borderColor?: number
-    borderAlpha?: number
-    borderThickness?: number
-    padding?: number
 }

--- a/src/components/player.ts
+++ b/src/components/player.ts
@@ -1,6 +1,7 @@
 // Authors: Omar Muhammad
 
 import type Scene from './scene'
+import type { Keys } from '../constants'
 
 const X_VELOCITY = 160
 const Y_VELOCITY = 300
@@ -23,7 +24,7 @@ export default class Player {
 
     scene: Scene
     sprite: Phaser.Types.Physics.Arcade.SpriteWithDynamicBody
-    cursors: Phaser.Types.Input.Keyboard.CursorKeys
+    keys: Keys
 
     constructor(scene: Scene) {
         this.scene = scene
@@ -60,12 +61,12 @@ export default class Player {
      * Initializes the player sprite and animations.
      */
     create() {
-        const sprite = this.scene.physics.add.sprite(100, 450, 'dude')
-        sprite.setBounce(0.2)
-        sprite.setCollideWorldBounds(true)
-
-        this.cursors = this.scene.input.keyboard.createCursorKeys()
-        this.sprite = sprite
+        this.sprite = this.scene.physics.add.sprite(100, 450, 'dude')
+            .setBounce(0.2)
+            .setCollideWorldBounds(true)
+        this.keys = Object.assign(this.scene.input.keyboard.createCursorKeys(), {
+            enter: this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ENTER)
+        })
 
         // initialize animations
         const prefix = 'dude'
@@ -114,12 +115,15 @@ export default class Player {
      * Updates the position of the player based on the current inputs.
      */
     update() {
-        if (this.cursors.left.isDown) {
+        // allow UI to capture input
+        if (this.scene.ui.handleInput(this.keys)) return
+
+        if (this.keys.left.isDown) {
             // move left
             this.lastDirection = Direction.Left
             this.sprite.setVelocityX(-X_VELOCITY)
             this.sprite.anims.play('dude_left', true)
-        } else if (this.cursors.right.isDown) {
+        } else if (this.keys.right.isDown) {
             // move right
             this.lastDirection = Direction.Right
             this.sprite.setVelocityX(X_VELOCITY)
@@ -130,13 +134,13 @@ export default class Player {
             this.sprite.anims.play('dude_turn')
         }
 
-        if (this.cursors.up.isDown && this.sprite.body.touching.down) {
+        if (this.keys.up.isDown && this.sprite.body.touching.down) {
             // jump
             this.sprite.setVelocityY(-Y_VELOCITY)
         }
 
         // fire
         // TODO: improve controls for this when combat is implemented
-        this.isFiring = this.cursors.space.isDown
+        this.isFiring = this.keys.space.isDown
     }
 }

--- a/src/components/ui.ts
+++ b/src/components/ui.ts
@@ -26,14 +26,6 @@ export default class UI {
         }
 
         this.dialogue.create()
-
-        // TODO: remove this. for testing purposes
-        this.dialogue.show([
-            'This is a test dialogue.',
-            'It has multiple lines.',
-            ['It also has a line ', 'which is split into ', 'multiple parts.'],
-            'Neat.'
-        ])
     }
 
     handleInput(keys: Keys): boolean {

--- a/src/components/ui.ts
+++ b/src/components/ui.ts
@@ -1,5 +1,6 @@
 // Authors: Omar Muhammad
 
+import DialogueBox from './dialogueBox'
 import type Scene from './scene'
 
 // the amount to add to the X position of each heart
@@ -7,8 +8,11 @@ const HEART_OFFSET = -8
 
 export default class UI {
     heartSprites: Phaser.GameObjects.Image[] = []
+    dialogueBox: DialogueBox
 
-    constructor(public scene: Scene) {}
+    constructor(public scene: Scene) {
+        this.dialogueBox = new DialogueBox(this)
+    }
 
     preload() {
         this.scene.load.image('heart', 'assets/heart.png')
@@ -19,6 +23,12 @@ export default class UI {
         if (this.scene.isCombatLevel) {
             this.renderLifeHearts()
         }
+
+        this.dialogueBox.create()
+
+        // TODO: remove this. for testing purposes
+        this.dialogueBox.setText('test')
+        this.dialogueBox.show()
     }
 
     removeLifeHearts() {

--- a/src/components/ui.ts
+++ b/src/components/ui.ts
@@ -1,17 +1,18 @@
 // Authors: Omar Muhammad
 
-import DialogueBox from './dialogueBox'
 import type Scene from './scene'
+import type { Keys } from '../constants'
+import DialogueManager from './dialogue'
 
 // the amount to add to the X position of each heart
 const HEART_OFFSET = -8
 
 export default class UI {
     heartSprites: Phaser.GameObjects.Image[] = []
-    dialogueBox: DialogueBox
+    dialogue: DialogueManager
 
     constructor(public scene: Scene) {
-        this.dialogueBox = new DialogueBox(this)
+        this.dialogue = new DialogueManager(this)
     }
 
     preload() {
@@ -24,11 +25,28 @@ export default class UI {
             this.renderLifeHearts()
         }
 
-        this.dialogueBox.create()
+        this.dialogue.create()
 
         // TODO: remove this. for testing purposes
-        this.dialogueBox.setText('test')
-        this.dialogueBox.show()
+        this.dialogue.show([
+            'This is a test dialogue.',
+            'It has multiple lines.',
+            ['It also has a line ', 'which is split into ', 'multiple parts.'],
+            'Neat.'
+        ])
+    }
+
+    handleInput(keys: Keys): boolean {
+        if (this.dialogue.visible) {
+            if (Phaser.Input.Keyboard.JustDown(keys.enter)) {
+                this.dialogue.skipOrMoveNext()
+            }
+
+            // capture input if the dialogue box is visible
+            return true
+        }
+
+        return false
     }
 
     removeLifeHearts() {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,3 +2,7 @@
 
 export const CANVAS_WIDTH = 800
 export const CANVAS_HEIGHT = 600
+
+export interface Keys extends Phaser.Types.Input.Keyboard.CursorKeys {
+    enter: Phaser.Input.Keyboard.Key
+}


### PR DESCRIPTION
Added a dialogue system. This handles drawing the dialogue box, suspending user input, and animating the text to appear letter-by-letter. This is intended to be interfaced via the reference in the `UI` class. An example, assumed to take place in a scene's `create` function (or somewhere within that context):

```js
this.ui.dialogue.show([
   'A single line of dialogue.',
   ['Multiple parts of a single line of dialogue ', 'which will display one-by-one.']
])
```

The use case of the "multiple parts" feature is to require user input to proceed to the next part of a line, for the illusion of a pause. Note the space in the first string in that array; dialogue parts will be concatenated together _exactly_ as they are.