### PR TITLE
Remove ES6 syntax from esbuild config file

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -1,9 +1,9 @@
 // adapted from Obsidian plugin template: https://github.com/obsidianmd/obsidian-sample-plugin
 // Authors: Omar Muhammad
 
-import esbuild from 'esbuild'
-import process from 'process'
-import { runServer } from './index.js'
+const esbuild = require('esbuild')
+const process = require('process')
+const { runServer } = require('./index.js')
 
 const mode = process.argv[2]
 const prod = mode === 'production'

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "dev": "node esbuild.config.mjs",
-    "start": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production && node . run"
+    "dev": "node esbuild.config.js",
+    "start": "tsc -noEmit -skipLibCheck && node esbuild.config.js production && node . run"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This fix should enable running the project on earlier versions of Node which don't support ES6 syntax.